### PR TITLE
Fixed start sh path and else conditional (SX-1489)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,6 @@ ADD . /locust
 
 WORKDIR /locust
 
-RUN chmod +x start.sh
+RUN chmod +x /locust/start.sh
 
-CMD start.sh
+CMD /locust/start.sh

--- a/start.sh
+++ b/start.sh
@@ -31,9 +31,9 @@ if [ "${LOCUST_MASTER_OR_SLAVE}" = "slave" ] && [ "${LOCUST_MASTER_HOST}" != "" 
 	  -c${LOCUST_CONCURRENT_CLIENTS} \
 	  -r${LOCUST_REQUEST_RATE} \
 	  ${LOCUST_ADDITIONAL_OPTIONS}	
-else if [ "${LOCUST_MASTER_OR_SLAVE}" = "slave" ] && [ "${LOCUST_MASTER_HOST}" = "" ]; then
+elif [ "${LOCUST_MASTER_OR_SLAVE}" = "slave" ] && [ "${LOCUST_MASTER_HOST}" = "" ]; then
 	echo "Please provide a LOCUST_MASTER_HOST variable for Locust slaves"
-else if [ "${LOCUST_MASTER_OR_SLAVE}" = "master" ]; then
+elif [ "${LOCUST_MASTER_OR_SLAVE}" = "master" ]; then
 	locust -f ${LOCUST_TESTS} \
 	  --${LOCUST_MASTER_OR_SLAVE} \
 	  --host=${LOCUST_TEST_HOST} \
@@ -44,5 +44,3 @@ else if [ "${LOCUST_MASTER_OR_SLAVE}" = "master" ]; then
 else
     echo "Please provide a LOCUST_MASTER_HOST variable for Locust slaves"
 fi
-
-


### PR DESCRIPTION
### Jira Ticket [SX-1489](https://singlecomm.atlassian.net/browse/SX-1489)
- [x] Ticket is linked in the title, ie `The Jira Ticket Title (SX-1489)`

###  Acceptance Criteria
- [x] Code Documentation (inline comments)
- [x] Unit Tests (wrote new tests and current tests passing)
- [x] Removed debug code
- [x] Inspected Code Diff
- [x] Added relevant QA information to Jira ticket

### An overview of the thinking process
I found the start.sh script had an `else if` instead `elif` conditional. Also, the script path was not pointing to the working directory.

### Anything you think you might break with this PR
none

### Anything you’d like the reviewers opinion on specifically
none